### PR TITLE
Add missing 'requests' dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def main():
         package_dir={'conda_press': 'conda_press'},
         package_data={'conda_press': ['*.xsh']},
         scripts=scripts,
-        install_requires=['xonsh', 'lazyasd', 'ruamel.yaml', 'tqdm'],
+        install_requires=['xonsh', 'lazyasd', 'ruamel.yaml', 'tqdm', 'requests'],
         python_requires=">=3.5",
         zip_safe=False,
         )


### PR DESCRIPTION
```
Traceback (most recent call last):
  ...
  File "/cmn/condaenvs/$env/lib/python3.7/site-packages/conda_press/condatools.xsh", line 18, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```