### PR TITLE
Some fixes for darwin and other things

### DIFF
--- a/conda_press/condatools.xsh
+++ b/conda_press/condatools.xsh
@@ -666,7 +666,7 @@ class ArtifactInfo:
                 dep.clean()
 
 
-def artifact_to_wheel(path, include_requirements=True, strip_symbols=True):
+def artifact_to_wheel(path, include_requirements=True, strip_symbols=True, skip_python=False):
     """Converts an artifact to a wheel. The clean option will remove
     the temporary artifact directory before returning.
     """
@@ -694,6 +694,8 @@ def artifact_to_wheel(path, include_requirements=True, strip_symbols=True):
         _remap_noarch_python(wheel, info)
     elif "python" in info.run_requirements:
         _remap_site_packages(wheel, info)
+        if skip_python:
+          info.run_requirements.pop('python')
     wheel.rewrite_python_shebang()
     wheel.rewrite_rpaths()
     wheel.rewrite_scripts_linking()
@@ -717,6 +719,7 @@ def package_to_wheel(ref_or_rec, channels=None, subdir=None,
         info,
         include_requirements=include_requirements,
         strip_symbols=strip_symbols,
+        skip_python=skip_python
     )
     wheel._top = _top
     return wheel

--- a/conda_press/condatools.xsh
+++ b/conda_press/condatools.xsh
@@ -170,7 +170,7 @@ def is_shared_lib(fname):
     if sys.platform.startswith('linux'):
         rtn = (ext == '.so')
     elif sys.platform.startswith('darwin'):
-        rtn = (ext == '.dylib')
+        rtn = (ext == '.dylib') || (ext == '.so') # cpython extensions use .so because ...?
     elif sys.platform.startswith('win'):
         rtn = (ext == '.dll')
     else:

--- a/conda_press/wheel.xsh
+++ b/conda_press/wheel.xsh
@@ -545,12 +545,15 @@ class Wheel:
             fspath = os.path.join(self.basedir, fsname)
             containing_dir = os.path.dirname(arcname)
             relpath_to_lib = os.path.relpath("lib/", containing_dir)
-            rpath_to_lib = "$ORIGIN/" + relpath_to_lib
             if sys.platform.startswith("linux"):
+                rpath_to_lib = "$ORIGIN/" + relpath_to_lib
                 current_rpath = $(patchelf --print-rpath @(fspath)).strip()
                 new_rpath = rpath_to_lib + ":" + current_rpath if current_rpath else new_rpath
                 print(f'  new RPATH is {new_rpath}')
                 $(patchelf --set-rpath @(new_rpath) @(fspath))
+            elif sys.platform == 'darwin':
+                rpath_to_lib = "@loader_path/" + relpath_to_lib
+                $(install_name_tool -add_rpath @(rpath_to_lib) @(fspath))
             else:
                 raise RuntimeError(f'cannot rewrite RPATHs on {sys.platform}')
 

--- a/news/pr16_darwin_misc.rst
+++ b/news/pr16_darwin_misc.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Initial support for RPATH fix-up on macOS
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Don't list python as a runtime requirement when building with '--skip-python'
+* Apply RPATH fixups to '.so' libraries on macOS, because that is CPython extension default
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_condatools.py
+++ b/tests/test_condatools.py
@@ -12,7 +12,7 @@ from conda_press.condatools import SYSTEM, SO_EXT
 
 ON_LINUX = (SYSTEM == "Linux")
 ON_WINDOWS = (SYSTEM == "Windows")
-
+ON_MAC = (SYSTEM == "Darwin")
 
 skip_if_not_on_linux = pytest.mark.skipif(not ON_LINUX, reason="can only be run on Linux")
 
@@ -142,3 +142,9 @@ def test_click(pip_install_artifact_tree, xonsh):
     # tests that we can create a click package
     # see https://github.com/regro/conda-press/issues/15
     wheels, test_env, sp = pip_install_artifact_tree("click=7.0=py_0", skip_python=True)
+
+def test_uvloop(pip_install_artifact_tree, xonsh):
+    # this should succeed after PR #16, because python will no longer be listed as a requirement
+    # FIXME add 'fatten' support to test harness
+    #wheel, test_env, sp = pip_install_artifact_tree("uvloop=0.12.2", skip_python=True, fatten=True)
+    pass


### PR DESCRIPTION
- CPython and Cython extensions are built as .so on darwin (🙃) 

- I couldn't install output wheel even with a matching python version because `python` was included in `Require-Dist`, and AFAICT pip doesn't introspect the python version (at least not there -- for `METADATA`). As a result, I was getting errors like below even when passing `--skip-python`:
```
Collecting python<3.8.0a0,>=3.7 (from tiledb-py==0.4.3)
  ERROR: Could not find a version that satisfies the requirement python<3.8.0a0,>=3.7 (from tiledb-py==0.4.3) (from versions: none)
ERROR: No matching distribution found for python<3.8.0a0,>=3.7 (from tiledb-py==0.4.3)
```

- works-for-me implementation of RPATH fix-up for darwin (will almost certainly need some iteration!)