### PR TITLE
Add new option `--only-pypi` 

### DIFF
--- a/conda_press/condatools.xsh
+++ b/conda_press/condatools.xsh
@@ -706,7 +706,6 @@ def get_only_deps_on_pypi(list_deps):
     set
         List of packages present on PyPi
     """
-    import requests
     new_deps = set()
     for pkg in list_deps:
         pkg_name_url = pkg.lower().replace("-", "_")

--- a/conda_press/condatools.xsh
+++ b/conda_press/condatools.xsh
@@ -398,13 +398,14 @@ def find_link_target(source, info=None, channels=None, deps_cache=None,
 class ArtifactInfo:
     """Representation of artifact info/ directory."""
 
-    def __init__(self, artifactdir, exclude_deps=None, add_deps=None):
+    def __init__(self, artifactdir, exclude_deps=None, add_deps=None, only_pypi=False):
         self._artifactdir = None
         self._python_tag = None
         self._abi_tag = None
         self._platform_tag = None
         self._run_requirements = None
         self._noarch = None
+        self._only_pypi = only_pypi
         self._entry_points = None
         self.index_json = None
         self.link_json = None
@@ -515,9 +516,14 @@ class ArtifactInfo:
         else:
             reqs = self.meta_yaml.get('requirements', {}).get('run', ())
 
-        reqs = set(reqs).union(set(self.add_deps)).difference(set(self.exclude_deps))
-        rr = dict([x.partition(' ')[::2] for x in reqs])
-        self._run_requirements = rr
+        reqs = set(reqs).union(set(self.add_deps))
+
+        if self._only_pypi:
+            reqs = get_only_deps_on_pypi(reqs)
+
+        reqs = reqs.difference(set(self.exclude_deps))
+
+        self._run_requirements = dict([x.partition(' ')[::2] for x in reqs])
         return self._run_requirements
 
     @property
@@ -625,7 +631,8 @@ class ArtifactInfo:
 
     @classmethod
     def from_tarball(cls, path, replace_symlinks=True, strip_symbols=True,
-                     skip_python=False, exclude_deps=None, add_deps=None):
+                     skip_python=False, exclude_deps=None, add_deps=None,
+                     only_pypi=False):
         base = os.path.basename(path)
         if base.endswith('.tar.bz2'):
             mode = 'r:bz2'
@@ -639,7 +646,7 @@ class ArtifactInfo:
         tmpdir = tempfile.mkdtemp(prefix=canonical_name)
         with tarfile.TarFile.open(path, mode=mode) as tf:
             tf.extractall(path=tmpdir)
-        info = cls(tmpdir, exclude_deps=exclude_deps, add_deps=add_deps)
+        info = cls(tmpdir, exclude_deps=exclude_deps, add_deps=add_deps, only_pypi=only_pypi)
         if skip_python and "python" in info.run_requirements:
             return info
         if strip_symbols:
@@ -687,8 +694,27 @@ class ArtifactInfo:
                 dep.clean()
 
 
+def get_only_deps_on_pypi(list_deps):
+    """Based on a list of dependencies this function will check if those
+    dependencies are on PyPi, if it is not available it will be removed.
+
+    :param set,list list_deps: List of dependencies as a string values
+    :return set: List of pakages present on PyPi
+    """
+    import requests
+    new_deps = set()
+    for pkg in list_deps:
+        response = requests.get(f"https://pypi.python.org/pypi/{pkg.lower()}/json")
+        if response.status_code == 200:
+            new_deps.add(pkg)
+        else:
+            print(f"Package {pkg} was not found on PyPi.")
+    return new_deps
+
+
 def artifact_to_wheel(path, include_requirements=True, strip_symbols=True,
-                      skip_python=False, exclude_deps=None, add_deps=None):
+                      skip_python=False, exclude_deps=None, add_deps=None,
+                      only_pypi=False):
     """Converts an artifact to a wheel. The clean option will remove
     the temporary artifact directory before returning.
     """
@@ -698,12 +724,14 @@ def artifact_to_wheel(path, include_requirements=True, strip_symbols=True,
     if isinstance(path, ArtifactInfo):
         path.exclude_deps = exclude_deps
         path.add_deps = add_deps
+        path._only_pypi=only_pypi
         info = path
     else:
         info = ArtifactInfo.from_tarball(
             path, strip_symbols=strip_symbols,
             exclude_deps=exclude_deps,
-            add_deps=add_deps
+            add_deps=add_deps,
+            only_pypi=only_pypi
         )
     # get names from meta.yaml
     for checker, getter in PACKAGE_SPEC_GETTERS:
@@ -737,7 +765,7 @@ def artifact_to_wheel(path, include_requirements=True, strip_symbols=True,
 def package_to_wheel(
         ref_or_rec, channels=None, subdir=None, include_requirements=True,
         strip_symbols=True,skip_python=False, _top=True, exclude_deps=None,
-        add_deps=None
+        add_deps=None, only_pypi=False
 ):
     """Converts a package ref spec or a PackageRecord into a wheel."""
     path = download_artifact(ref_or_rec, channels=channels, subdir=subdir)
@@ -748,7 +776,8 @@ def package_to_wheel(
         path, strip_symbols=strip_symbols,
         skip_python=skip_python,
         exclude_deps=exclude_deps,
-        add_deps=add_deps
+        add_deps=add_deps,
+        only_pypi=only_pypi
     )
     if skip_python and not _top and "python" in info.run_requirements:
         return None
@@ -758,7 +787,8 @@ def package_to_wheel(
         strip_symbols=strip_symbols,
         skip_python=skip_python,
         exclude_deps=exclude_deps,
-        add_deps=add_deps
+        add_deps=add_deps,
+        only_pypi=only_pypi
     )
     wheel._top = _top
     return wheel
@@ -767,7 +797,7 @@ def package_to_wheel(
 def artifact_ref_dependency_tree_to_wheels(
         artifact_ref, channels=None, subdir=None, seen=None,
         include_requirements=True, skip_python=False, strip_symbols=True,
-        exclude_deps=None, add_deps=None
+        exclude_deps=None, add_deps=None, only_pypi=False
 ):
     """Converts all artifact dependencies to wheels for a ref spec string"""
     seen = {} if seen is None else seen
@@ -824,7 +854,8 @@ def artifact_ref_dependency_tree_to_wheels(
             strip_symbols=strip_symbols,
             _top=is_top,
             exclude_deps=exclude_deps,
-            add_deps=add_deps
+            add_deps=add_deps,
+            only_pypi=only_pypi
         )
         seen[match_spec_str] = wheel
 

--- a/conda_press/main.xsh
+++ b/conda_press/main.xsh
@@ -32,6 +32,14 @@ def main(args=None):
                    help="Exclude dependencies from conda package.")
     p.add_argument("--add-deps", dest="add_deps", default=None, nargs="+",
                    help="Add dependencies to the wheel.")
+    p.add_argument(
+        "--only-pypi",
+        dest="only_pypi",
+        default=False,
+        action="store_true",
+        help="Remove dependencies which are not on PyPi when converting conda "
+            "package to Python wheel.",
+    )
     ns = p.parse_args(args=args)
     channels = tuple(ns.channels) + DEFAULT_CHANNELS
 
@@ -51,7 +59,8 @@ def main(args=None):
                 strip_symbols=ns.strip_symbols,
                 channels=channels,
                 exclude_deps=ns.exclude_deps,
-                add_deps=ns.add_deps
+                add_deps=ns.add_deps,
+                only_pypi=ns.only_pypi
             )
             if ns.fatten:
                 fatten_from_seen(seen, output=ns.output)
@@ -59,7 +68,7 @@ def main(args=None):
             print(f'Converting {fname} to wheel')
             artifact_to_wheel(fname, strip_symbols=ns.strip_symbols,
                               exclude_deps=ns.exclude_deps,
-                              add_deps=ns.add_deps)
+                              add_deps=ns.add_deps, only_pypi=ns.only_pypi)
 
 
 if __name__ == "__main__":

--- a/news/fb-29-only-pypi.md
+++ b/news/fb-29-only-pypi.md
@@ -1,0 +1,24 @@
+**Added:**
+
+* Add new option `--only-pypi` which will remove any dependency which is not available on PyPi.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_condatools.py
+++ b/tests/test_condatools.py
@@ -181,7 +181,7 @@ def test_get_only_deps_on_pypi_by_artifact(tmpdir, xonsh, data_folder):
 
 
 def test_get_only_deps_on_pypi():
-    assert get_only_deps_on_pypi(["pytest", "pytest-xdist"]) == {"pytest", "pytest-xdis"}
+    assert get_only_deps_on_pypi(["pytest", "pytest-xdist"]) == {"pytest", "pytest-xdist"}
     assert get_only_deps_on_pypi(["pytest", "NOT_PACKAGE_000"]) == {"pytest"}
     assert get_only_deps_on_pypi(["pytest", "requests"]) == {"pytest", "requests"}
 

--- a/tests/test_condatools.py
+++ b/tests/test_condatools.py
@@ -7,7 +7,7 @@ import subprocess
 
 import pytest
 
-from conda_press.condatools import SYSTEM, SO_EXT, artifact_to_wheel
+from conda_press.condatools import SYSTEM, SO_EXT, artifact_to_wheel, get_only_deps_on_pypi
 
 
 ON_LINUX = (SYSTEM == "Linux")
@@ -170,3 +170,16 @@ def test_exclude_add_deps(xonsh, data_folder, tmpdir):
         )
         assert "opencv" in wheel.artifact_info.run_requirements
         assert "six" in wheel.artifact_info.run_requirements
+
+
+def test_get_only_deps_on_pypi_by_artifact(tmpdir, xonsh, data_folder):
+    with tmpdir.as_cwd():
+        conda_pkg = os.path.join(data_folder, "test-deps-0.0.1-py_0.tar.bz2")
+        wheel = artifact_to_wheel(conda_pkg, add_deps=["pytest"], only_pypi=True)
+        assert "opencv" not in wheel.artifact_info.run_requirements
+        assert "pytest" in wheel.artifact_info.run_requirements
+
+
+def test_get_only_deps_on_pypi():
+    assert get_only_deps_on_pypi(["pytest", "NOT_PACKAGE_000"]) == {"pytest"}
+    assert get_only_deps_on_pypi(["pytest", "requests"]) == {"pytest", "requests"}

--- a/tests/test_condatools.py
+++ b/tests/test_condatools.py
@@ -181,6 +181,7 @@ def test_get_only_deps_on_pypi_by_artifact(tmpdir, xonsh, data_folder):
 
 
 def test_get_only_deps_on_pypi():
+    assert get_only_deps_on_pypi(["pytest", "pytest-xdist"]) == {"pytest", "pytest-xdis"}
     assert get_only_deps_on_pypi(["pytest", "NOT_PACKAGE_000"]) == {"pytest"}
     assert get_only_deps_on_pypi(["pytest", "requests"]) == {"pytest", "requests"}
 


### PR DESCRIPTION
Add new option `--only-pypi` which will remove all dependencies which are not available on PyPi.

It closes #30 

cc: @scopatz 

