### PR TITLE
Add ``--config`` option which accepts a YAML file

### DIFF
--- a/conda_press/config.py
+++ b/conda_press/config.py
@@ -125,7 +125,7 @@ def get_config_by_yaml(yaml_path, config=None):
         return yaml_var
 
     config.add_deps = convert_to_set(yaml_attr("add_deps"))
-    config.add_deps = convert_to_set(yaml_attr("add_deps"))
+    config.exclude_deps = convert_to_set(yaml_attr("exclude_deps"))
     config.only_pypi = yaml_attr("only_pypi")
     config.include_requirements = yaml_attr("include_requirements")
     return config

--- a/conda_press/config.py
+++ b/conda_press/config.py
@@ -67,3 +67,11 @@ class Config:
             Returns a set with the dependencies.
         """
         return set(list_deps).union(self.add_deps).difference(self.exclude_deps)
+
+
+def populate_config_by_yaml(yaml_path, config):
+    from ruamel.yaml import YAML
+
+    with open(yaml_path, "r") as config_file:
+        yaml_file = YAML(typ="safe").load(config_file)
+

--- a/conda_press/config.py
+++ b/conda_press/config.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Union, List, Set, Tuple
 
 CACHE_DIR = os.path.join(tempfile.gettempdir(), "artifact-cache")
@@ -69,9 +69,63 @@ class Config:
         return set(list_deps).union(self.add_deps).difference(self.exclude_deps)
 
 
-def populate_config_by_yaml(yaml_path, config):
+def get_config_by_yaml(yaml_path, config=None):
+    """Free function responsible to create or fill a `Config` object
+    with the content of a yaml file.
+
+    Parameters
+    ----------
+    yaml_path : str
+        Path to the YAML file
+    config : Config, optional
+        If it is received a Config object it will be filled otherwise
+        this function will create a new Config object.
+
+    Returns
+    -------
+    Config
+        Config object with the yaml configuration
+
+    """
     from ruamel.yaml import YAML
 
-    with open(yaml_path, "r") as config_file:
-        yaml_file = YAML(typ="safe").load(config_file)
+    if config is None:
+        config = Config()
 
+    with open(yaml_path, "r") as config_file:
+        yaml = YAML(typ="safe").load(config_file)
+
+    def convert_to_list(yaml_var):
+        if isinstance(yaml_var, str):
+            return [yaml_var]
+        return yaml_var
+
+    def yaml_attr(attr):
+        if yaml.get(attr) is not None:
+            return yaml.get(attr)
+        return asdict(config)[attr]
+
+    if isinstance(yaml_attr("subdir"), list):
+        config.subdir = tuple(yaml.subdir)
+    else:
+        config.subdir = yaml_attr("subdir")
+
+    config.output = yaml_attr("output")
+    config.channels = convert_to_list(yaml_attr("channels"))
+    config.fatten = yaml_attr("fatten")
+    config.skip_python = yaml_attr("skip_python")
+    config.strip_symbols = yaml_attr("strip_symbols")
+    config.merge = yaml_attr("merge")
+
+    def convert_to_set(yaml_var):
+        if isinstance(yaml_var, str):
+            return {yaml_var}
+        if isinstance(yaml_var, list):
+            return set(yaml_var)
+        return yaml_var
+
+    config.add_deps = convert_to_set(yaml_attr("add_deps"))
+    config.add_deps = convert_to_set(yaml_attr("add_deps"))
+    config.only_pypi = yaml_attr("only_pypi")
+    config.include_requirements = yaml_attr("include_requirements")
+    return config

--- a/conda_press/main.xsh
+++ b/conda_press/main.xsh
@@ -40,13 +40,15 @@ def main(args=None):
         help="Remove dependencies which are not on PyPi when converting conda "
             "package to Python wheel.",
     )
+    p.add_argument(
+        "--config",
+        dest="config_file",
+        default=None,
+        nargs=1,
+        help="Receives an yaml configuration file which will set the options for conda-press.\n"
+             "This option has high priority over the others to configure conda-press.",
+    )
     ns = p.parse_args(args=args)
-
-    if ns.merge:
-        wheels = {f: Wheel.from_file(f) for f in ns.files}
-        output = ns.files[-1] if ns.output is None else ns.output
-        merge(wheels, output=output)
-        return
 
     config = Config(
         output=ns.output,
@@ -60,6 +62,16 @@ def main(args=None):
         skip_python=ns.skip_python,
         only_pypi=ns.only_pypi,
     )
+
+    if ns.config_file:
+        populate_config_by_yaml(config)
+
+    if ns.merge:
+        wheels = {f: Wheel.from_file(f) for f in ns.files}
+        output = ns.files[-1] if ns.output is None else ns.output
+        merge(wheels, output=output)
+        return
+
 
     for fname in ns.files:
         if "=" in fname:

--- a/conda_press/main.xsh
+++ b/conda_press/main.xsh
@@ -1,7 +1,7 @@
 """CLI entry point for conda-press"""
 from argparse import ArgumentParser
 
-from conda_press.config import Config
+from conda_press.config import Config, get_config_by_yaml
 from conda_press.wheel import Wheel, merge, fatten_from_seen
 from conda_press.condatools import (
     artifact_to_wheel,
@@ -64,14 +64,13 @@ def main(args=None):
     )
 
     if ns.config_file:
-        populate_config_by_yaml(config)
+        get_config_by_yaml(ns.config_file, config)
 
     if ns.merge:
         wheels = {f: Wheel.from_file(f) for f in ns.files}
         output = ns.files[-1] if ns.output is None else ns.output
         merge(wheels, output=output)
         return
-
 
     for fname in ns.files:
         if "=" in fname:

--- a/news/fb-36-add-config-option.md
+++ b/news/fb-36-add-config-option.md
@@ -1,0 +1,24 @@
+**Added:**
+
+* Added option `--config` which accepts a path to a yaml file with the configuration to run `conda-press`.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,4 +61,4 @@ def test_populate_config_by_yaml(tmpdir):
         "include_requirements": False,
     }
     yaml_path.write(yaml.dump(config_content))
-    assert get_config_by_yaml(str(yaml_path))
+    assert get_config_by_yaml(str(yaml_path)) == config_content

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 import pytest
+from ruamel import yaml
 
 from conda_press.config import Config
+
 
 @pytest.fixture
 def config_obj(tmpdir):
@@ -21,8 +23,8 @@ def config_obj(tmpdir):
 
 def test_fields(config_obj):
     assert (
-        config_obj.channels.sort()
-        == ["FOO-CHANNEL", "conda-forge", "anaconda", "main", "r"].sort()
+            config_obj.channels.sort()
+            == ["FOO-CHANNEL", "conda-forge", "anaconda", "main", "r"].sort()
     )
     assert config_obj.subdir == ("SUBDIR", "noarch")
     assert config_obj.output == "OUTPUT"
@@ -41,3 +43,21 @@ def test_clean_deps(config_obj):
     config_obj.exclude_deps = {"DEP2", "DEP4"}
     all_deps = ["DEP0", "DEP1", "DEP2", "DEP5"]
     assert config_obj.clean_deps(all_deps) == {"DEP0", "DEP1", "DEP3", "DEP5"}
+
+
+def test_populate_config_by_yaml(tmpdir):
+    yaml_path = tmpdir.join("TEST.yaml")
+    yaml_path.write(yaml.dump({
+        "subdir": "SUBDIR",
+        "output": "OUTPUT",
+        "channels": ["FOO-CHANNEL", "CHANNEL2"],
+        "fatten": True,
+        "skip_python": True,
+        "strip_symbols": False,
+        "merge": True,
+        "exclude_deps": ["EXCLUDE1", "EXCLUDE2"],
+        "add_deps": ["ADD1", "ADD2"],
+        "only_pypi": True,
+        "include_requirements": False,
+    }))
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 from ruamel import yaml
 
-from conda_press.config import Config, get_config_by_yaml
+from conda_press.config import Config, get_config_by_yaml, DEFAULT_CHANNELS
 
 
 @pytest.fixture
@@ -61,4 +61,18 @@ def test_populate_config_by_yaml(tmpdir):
         "include_requirements": False,
     }
     yaml_path.write(yaml.dump(config_content))
-    assert get_config_by_yaml(str(yaml_path)) == config_content
+    config_read = get_config_by_yaml(str(yaml_path))
+    assert config_read.subdir == (config_content["subdir"], "noarch")
+    assert config_read.output == config_content["output"]
+    assert sorted(config_read.channels) == sorted(config_content["channels"] + list(DEFAULT_CHANNELS))
+    assert config_read.fatten == config_content["fatten"]
+    assert config_read.skip_python == config_content["skip_python"]
+    assert config_read.strip_symbols == config_content["strip_symbols"]
+    assert config_read.merge == config_content["merge"]
+    assert config_read.exclude_deps == set(config_content["exclude_deps"])
+    assert config_read.add_deps == set(config_content["add_deps"])
+    assert config_read.only_pypi == config_content["only_pypi"]
+    assert config_read.include_requirements == config_content["include_requirements"]
+
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 from ruamel import yaml
 
-from conda_press.config import Config
+from conda_press.config import Config, get_config_by_yaml
 
 
 @pytest.fixture
@@ -23,8 +23,8 @@ def config_obj(tmpdir):
 
 def test_fields(config_obj):
     assert (
-            config_obj.channels.sort()
-            == ["FOO-CHANNEL", "conda-forge", "anaconda", "main", "r"].sort()
+        config_obj.channels.sort()
+        == ["FOO-CHANNEL", "conda-forge", "anaconda", "main", "r"].sort()
     )
     assert config_obj.subdir == ("SUBDIR", "noarch")
     assert config_obj.output == "OUTPUT"
@@ -47,7 +47,7 @@ def test_clean_deps(config_obj):
 
 def test_populate_config_by_yaml(tmpdir):
     yaml_path = tmpdir.join("TEST.yaml")
-    yaml_path.write(yaml.dump({
+    config_content = {
         "subdir": "SUBDIR",
         "output": "OUTPUT",
         "channels": ["FOO-CHANNEL", "CHANNEL2"],
@@ -59,5 +59,6 @@ def test_populate_config_by_yaml(tmpdir):
         "add_deps": ["ADD1", "ADD2"],
         "only_pypi": True,
         "include_requirements": False,
-    }))
-
+    }
+    yaml_path.write(yaml.dump(config_content))
+    assert get_config_by_yaml(str(yaml_path))


### PR DESCRIPTION
Added the option ``--config`` which accepts a path to a yaml file with the configuration to run `conda-press`.