### PR TITLE
Improvements on `--config`

### DIFF
--- a/conda_press/condatools.xsh
+++ b/conda_press/condatools.xsh
@@ -751,7 +751,7 @@ def package_to_wheel(ref_or_rec, config=None, _top=True):
     if config is None:
         config = Config()
     path = download_artifact(
-        ref_or_rec, channels=config.channels, subdir=config.subdir
+        ref_or_rec, channels=config.get_all_channels(), subdir=config.get_all_subdir()
     )
     if path is None:
         # happens for cloudpickle>=0.2.1
@@ -772,7 +772,7 @@ def artifact_ref_dependency_tree_to_wheels(artifact_ref, config=None, seen=None)
     top_name = name_from_ref(artifact_ref)
     top_found = False
 
-    solver = Solver("<none>", config.channels, subdirs=config.subdir, specs_to_add=(artifact_ref,))
+    solver = Solver("<none>", config.get_all_channels(), subdirs=config.get_all_subdir(), specs_to_add=(artifact_ref,))
     package_recs = solver.solve_final_state()
 
     if config.skip_python:

--- a/news/fb-conda-press-key-config.md
+++ b/news/fb-conda-press-key-config.md
@@ -1,0 +1,25 @@
+**Added:**
+
+* The `YAML` file passed using the option `--config` also accepts the 
+configuration to be inside of the key `conda_press`.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 from ruamel import yaml
 
-from conda_press.config import Config, get_config_by_yaml, DEFAULT_CHANNELS
+from conda_press.config import Config, get_config_by_yaml
 
 
 @pytest.fixture
@@ -22,11 +22,17 @@ def config_obj(tmpdir):
 
 
 def test_fields(config_obj):
-    assert (
-        config_obj.channels.sort()
-        == ["FOO-CHANNEL", "conda-forge", "anaconda", "main", "r"].sort()
-    )
-    assert config_obj.subdir == ("SUBDIR", "noarch")
+    assert config_obj.get_all_channels() == [
+        "FOO-CHANNEL",
+        "CHANNEL2",
+        "conda-forge",
+        "anaconda",
+        "main",
+        "r",
+    ]
+    assert config_obj.channels == ["FOO-CHANNEL", "CHANNEL2"]
+    assert config_obj.get_all_subdir() == ["SUBDIR", "noarch"]
+    assert config_obj.subdir == "SUBDIR"
     assert config_obj.output == "OUTPUT"
     assert config_obj.fatten
     assert config_obj.skip_python
@@ -45,34 +51,45 @@ def test_clean_deps(config_obj):
     assert config_obj.clean_deps(all_deps) == {"DEP0", "DEP1", "DEP3", "DEP5"}
 
 
-def test_populate_config_by_yaml(tmpdir):
+DICT_CONFIG_CONTENT = {
+    "subdir": "SUBDIR",
+    "output": "OUTPUT",
+    "channels": ["FOO-CHANNEL", "CHANNEL2"],
+    "fatten": True,
+    "skip_python": True,
+    "strip_symbols": False,
+    "merge": True,
+    "exclude_deps": ["EXCLUDE1", "EXCLUDE2"],
+    "add_deps": ["ADD1", "ADD2"],
+    "only_pypi": True,
+    "include_requirements": False,
+}
+
+
+@pytest.mark.parametrize(
+    "config_content", [DICT_CONFIG_CONTENT, {"conda_press": DICT_CONFIG_CONTENT}]
+)
+def test_populate_config_by_yaml(config_content, tmpdir):
     yaml_path = tmpdir.join("TEST.yaml")
-    config_content = {
-        "subdir": "SUBDIR",
-        "output": "OUTPUT",
-        "channels": ["FOO-CHANNEL", "CHANNEL2"],
-        "fatten": True,
-        "skip_python": True,
-        "strip_symbols": False,
-        "merge": True,
-        "exclude_deps": ["EXCLUDE1", "EXCLUDE2"],
-        "add_deps": ["ADD1", "ADD2"],
-        "only_pypi": True,
-        "include_requirements": False,
-    }
     yaml_path.write(yaml.dump(config_content))
     config_read = get_config_by_yaml(str(yaml_path))
-    assert config_read.subdir == (config_content["subdir"], "noarch")
-    assert config_read.output == config_content["output"]
-    assert sorted(config_read.channels) == sorted(config_content["channels"] + list(DEFAULT_CHANNELS))
-    assert config_read.fatten == config_content["fatten"]
-    assert config_read.skip_python == config_content["skip_python"]
-    assert config_read.strip_symbols == config_content["strip_symbols"]
-    assert config_read.merge == config_content["merge"]
-    assert config_read.exclude_deps == set(config_content["exclude_deps"])
-    assert config_read.add_deps == set(config_content["add_deps"])
-    assert config_read.only_pypi == config_content["only_pypi"]
-    assert config_read.include_requirements == config_content["include_requirements"]
-
-
-
+    assert config_read.channels == ["FOO-CHANNEL", "CHANNEL2"]
+    assert config_read.get_all_channels() == [
+        "FOO-CHANNEL",
+        "CHANNEL2",
+        "conda-forge",
+        "anaconda",
+        "main",
+        "r",
+    ]
+    assert config_read.subdir == "SUBDIR"
+    assert config_read.get_all_subdir() == ["SUBDIR", "noarch"]
+    assert config_read.output == "OUTPUT"
+    assert config_read.fatten
+    assert config_read.skip_python
+    assert not config_read.strip_symbols
+    assert config_read.merge
+    assert config_read.exclude_deps == {"EXCLUDE1", "EXCLUDE2"}
+    assert config_read.add_deps == {"ADD1", "ADD2"}
+    assert config_read.only_pypi
+    assert not config_read.include_requirements


### PR DESCRIPTION
The YAML configuration file also accepts the key `conda_press` where the configuration file to run `conda-press` is located.
This modification is useful when loaded a configuration file with other keys which do not concern to `conda-press`.